### PR TITLE
Fix typo: Gubio -> Gubbio

### DIFF
--- a/_layouts/table.html
+++ b/_layouts/table.html
@@ -702,7 +702,7 @@
                         41.2
                     </td>
                     <td>
-                        Contessa highway section near Gubio, Central Apennines, Italy
+                        Contessa highway section near Gubbio, Central Apennines, Italy
                     </td>
                     <td>
                         &nbsp;


### PR DESCRIPTION
Fix typo: in Italian the name of the town is Gubbio, not Gubio. See this same table the golden spike in "Campanian Stage" where we found the correct spelling "Gubbio".